### PR TITLE
Fixed build, Network selection and smart contract function execution bugs.

### DIFF
--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -15,7 +15,7 @@ const {
   MAINNET_RPC_URL,
 } = require('./enums')
 const LOCALHOST_RPC_URL = 'http://localhost:8293'
-const INFURA_PROVIDER_TYPES = []
+const INFURA_PROVIDER_TYPES = [MAINNET]
 
 const env = process.env.METAMASK_ENV
 const METAMASK_DEBUG = process.env.METAMASK_DEBUG
@@ -117,10 +117,13 @@ module.exports = class NetworkController extends EventEmitter {
     const { type, rpcTarget } = opts
     // infura type-based endpoints
     const isInfura = INFURA_PROVIDER_TYPES.includes(type)
-    if (isInfura) {
+	// I believe we can use infuria to lookup nuko mainnet.
+	// Someone would need to register and set it up with the nuko MAINNET_RPC_URL.
+	// Then figure out where the Infuria API key would go
+    /*if (isInfura) {
       this._configureInfuraProvider(opts)
     // other type-based rpc endpoints
-    } else if (type === MAINNET) {
+    } else*/ if (type === MAINNET) {
       this._configureStandardProvider({ rpcUrl: MAINNET_RPC_URL })
     } else if (type === LOCALHOST) {
       this._configureStandardProvider({ rpcUrl: LOCALHOST_RPC_URL })
@@ -177,7 +180,7 @@ module.exports = class NetworkController extends EventEmitter {
   }
 
   _logBlock (block) {
-    log.info(`BLOCK CHANGED: #${block.number.toString('hex')} 0x${block.hash.toString('hex')}`)
+    //log.debug(`BLOCK CHANGED: #${block.number.toString('hex')} 0x${block.hash.toString('hex')}`)
     this.verifyNetwork()
   }
 }

--- a/app/scripts/controllers/network/network.js
+++ b/app/scripts/controllers/network/network.js
@@ -117,9 +117,9 @@ module.exports = class NetworkController extends EventEmitter {
     const { type, rpcTarget } = opts
     // infura type-based endpoints
     const isInfura = INFURA_PROVIDER_TYPES.includes(type)
-	// I believe we can use infuria to lookup nuko mainnet.
+	// I believe we can use infura to lookup nuko mainnet.
 	// Someone would need to register and set it up with the nuko MAINNET_RPC_URL.
-	// Then figure out where the Infuria API key would go
+	// Then figure out where the Infura API key would go
     /*if (isInfura) {
       this._configureInfuraProvider(opts)
     // other type-based rpc endpoints

--- a/app/scripts/lib/createErrorMiddleware.js
+++ b/app/scripts/lib/createErrorMiddleware.js
@@ -47,7 +47,7 @@ function sanitizeRPCError (error, override) {
 
 /**
  * json-rpc-engine middleware that both logs standard and non-standard error
- * messages and ends middleware stack traversal if an error is encountered
+ * messages
  *
  * @param {MiddlewareConfig} [config={override:true}] - Middleware configuration
  * @returns {Function} json-rpc-engine middleware function
@@ -59,6 +59,7 @@ function createErrorMiddleware ({ override = true } = {}) {
       if (!error) { return done() }
       sanitizeRPCError(error)
       log.error(`MetaMask - RPC Error: ${error.message}`, error)
+	  return done()
     })
   }
 }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
     "fast-levenshtein": "^2.0.6",
     "file-loader": "^1.1.11",
     "fuse.js": "^3.2.0",
-    "gulp": "github:gulpjs/gulp#4.0",
+    "gulp": "^4.0.0",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-debug": "^3.2.0",
     "gulp-eslint": "^4.0.0",


### PR DESCRIPTION
 - Updated dependency gulp to use the default npm gulp 4.0.0 package because the "github:gulpjs/gulp#4.0" path seems to be dead.

createErrorMiddleware.js
 - Edited createErrorMiddleware function to return done() even on error so web3 contract function calls can complete properly.

network.js
 - Restored the MAINNET constant in the INFURA_PROVIDER_TYPES array to fix mainnet selection.
 - Modified NetworkController::_configureProvider method to skip Infura provider evaluation.  Nuko needs to be setup with Infura and we can go back to using it.
 - Closes #2